### PR TITLE
fix: CommentsController に認証・認可を追加

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,4 +1,8 @@
 class CommentsController < ApplicationController
+  before_action :authenticate_user!, only: %i[create destroy]
+  before_action :set_comment, only: [:destroy]
+  before_action :correct_comment_user, only: [:destroy]
+
   def create
     comment = current_user.comments.build(comment_params)
     if comment.save
@@ -12,13 +16,20 @@ class CommentsController < ApplicationController
   end
 
   def destroy
-    comment = Comment.find(params[:id])
-    comment.destroy
+    @comment.destroy
     flash[:success] = 'コメントが削除されました'
-    redirect_to comment.post
+    redirect_to @comment.post
   end
 
   private
+
+  def set_comment
+    @comment = Comment.find(params[:id])
+  end
+
+  def correct_comment_user
+    redirect_to(root_url) unless @comment.user == current_user || current_user.admin?
+  end
 
   def comment_params
     params.require(:comment).permit(:comment, :post_id, :user_id)


### PR DESCRIPTION
- before_action :authenticate_user! で create/destroy をログイン必須に
- コメント削除は本人または管理者のみ許可 (correct_comment_user)